### PR TITLE
Mark GNOME shell 40.1 as compatible

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "3.36",
     "3.38",
-    "40.0"
+    "40.0",
+    "40.1"
   ],
   "url": "https://github.com/laurento/gnome-shell-extension-ideapad",
   "version": 3


### PR DESCRIPTION
Tested with my own installation, I want it to be installable from the web again