### PR TITLE
Add udev rule for conservation mode file permissions

### DIFF
--- a/99-ideapad-conservation.rules
+++ b/99-ideapad-conservation.rules
@@ -1,0 +1,7 @@
+# Rule to set group ownership and permissions for the conservation mode file
+# This allows members of the 'users' or 'power' group to write to the file
+# The wildcard KERNEL=="VPC*:*" matches the specific platform device
+ACTION=="add", SUBSYSTEM=="platform", DRIVERS=="ideapad_acpi", KERNEL=="VPC*:*", \
+  ATTR{conservation_mode}=="*", \
+  RUN+="/usr/bin/chown root:power /sys/%p/conservation_mode", \
+  RUN+="/usr/bin/chmod 664 /sys/%p/conservation_mode"


### PR DESCRIPTION
This rule sets group ownership and permissions for the conservation mode file, allowing 'users' or 'power' group members to write to it. So no manual intervention is needed.