### PR TITLE
Add support for GNOME 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
     "46",
     "47",
     "48",
-    "49"
+    "49",
+    "50"
   ],
   "url": "https://github.com/laurento/gnome-shell-extension-ideapad",
   "version": 21


### PR DESCRIPTION
Tested on Fedora 44 with GNOME 50. The extension works perfectly without any further code changes required.